### PR TITLE
Update default cpp version string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plxsversion"
-version = "1.2.0"
+version = "2.0.0"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 

--- a/readme.md
+++ b/readme.md
@@ -74,23 +74,28 @@ Other parameters can be found in the public interface for the module.
 - Git repo the tool runs in must have at least 1 valid commit
 
 #### Tag Format
+This tool expects git tags to follow Semantic Versioning 2.0.0 (SemVer).
+The version string itself should be of the form `X.Y.Z[-PRERELEASE][+BUILD_METADATA]`.
+A leading `v` (e.g., `v1.2.3`) in the git tag is permitted and will be stripped by the tool before parsing the SemVer string.
 
-The general structure of valid tag formats is based on semantic versioning with an additional descriptor field. This ends up looking like `<major>.<minor>.<patch>-<my>_<descriptor>`. The descriptor field expects an alpha-numeric string that can be separated using underscores. 
+- **PRERELEASE**: A series of dot-separated identifiers. Identifiers are composed of ASCII alphanumerics and hyphens. Numeric identifiers MUST NOT have leading zeros (e.g., `1.0.0-alpha.1`, `1.0.0-rc.2`).
+- **BUILD_METADATA**: A series of dot-separated identifiers. Identifiers are composed of ASCII alphanumerics and hyphens (e.g., `1.0.0+build.123`, `1.0.0-alpha+007.exp`).
 
 Examples of valid formats:
 
 - 1.2.3
 - v1.2.3
-- 1.2.3-MyMilestone
-- v1.2.3-MyMilestone_RC3
+- 1.0.0-alpha
+- v1.0.0-alpha.1
+- 1.0.0-beta+build.123.abc
+- 0.0.1-SNAPSHOT.12
 
 Examples of invalid formats:
 
 - v1.2
-- 1.2-MyMilestone
-- v1.2.3MyMilestone
-- 1.2.3-MyMilestone-RC2
-- 1.2.3-MyMilestone.RC2
+- 1.2.3-My_Milestone (underscores are not allowed in pre-release or build metadata identifiers)
+- 1.2.3-alpha..beta (empty pre-release identifier)
+- 1.0.0-01 (leading zero in numeric pre-release identifier)
 
 #### Supported Tag Sources
 
@@ -117,7 +122,8 @@ The created file contains the following information:
 | MAJOR                   | The semantic major component of the tag |
 | MINOR                   | The semantic minor component of the tag |
 | PATCH                   | The semantic patch component of the tag |
-| VERSION_DESCRIPTOR      | The descriptive component of the tag |
+| PRE_RELEASE             | The pre-release component of the tag |
+| BUILD_METADATA          | The metadata component of the tag |
 | TAG                     | The raw tag before processing |
 | COMMITS_SINCE_TAG       | Number of commits since the last tag (defaults to 0 if using file for semantic version) |
 | COMMIT_ID               | Commit ID of the git commit used to build |
@@ -145,11 +151,12 @@ Here is an example output version.hpp file for a C++ application tagged `2.1.0` 
 
 namespace plxsversion {
 
-inline constexpr std::string_view VERSION { "2.1.0-dirty" };
+inline constexpr std::string_view VERSION { "2.1.0+dd4c559.dirty" };
 inline constexpr unsigned int MAJOR { 2 };
 inline constexpr unsigned int MINOR { 1 };
 inline constexpr unsigned int PATCH { 0 };
-inline constexpr std::string_view VERSION_DESCRIPTOR { "" };
+inline constexpr std::string_view PRE_RELEASE { "" };
+inline constexpr std::string_view BUILD_METADATA { "" };
 inline constexpr std::string_view TAG { "2.1.0" };
 inline constexpr unsigned int COMMITS_SINCE_TAG { 0 };
 inline constexpr std::string_view COMMIT_ID { "dd4c559" };

--- a/readme.md
+++ b/readme.md
@@ -76,9 +76,9 @@ Other parameters can be found in the public interface for the module.
 #### Tag Format
 This tool expects git tags to follow Semantic Versioning 2.0.0 (SemVer).
 The version string itself should be of the form `X.Y.Z[-PRERELEASE][+BUILD_METADATA]`.
-A leading `v` (e.g., `v1.2.3`) in the git tag is permitted and will be stripped by the tool before parsing the SemVer string.
+A leading `v` (e.g., `v1.2.3`) in the git tag is permitted and will be stripped by the tool before parsing the SemVer string. PRERLEASE and BUILD_METADATA are optional for a tag. They can be used to provide addtional contextual data about a build which would be incorporated into a version string. 
 
-- **PRERELEASE**: A series of dot-separated identifiers. Identifiers are composed of ASCII alphanumerics and hyphens. Numeric identifiers MUST NOT have leading zeros (e.g., `1.0.0-alpha.1`, `1.0.0-rc.2`).
+- **PRERELEASE**: A series of dot-separated identifiers. Identifiers are composed of ASCII alphanumerics and hyphens. Numeric identifiers MUST NOT have leading zeros (e.g., `1.0.0-alpha.1`, `1.0.0-rc.2`, `1.0.0-MyMilestone`).
 - **BUILD_METADATA**: A series of dot-separated identifiers. Identifiers are composed of ASCII alphanumerics and hyphens (e.g., `1.0.0+build.123`, `1.0.0-alpha+007.exp`).
 
 Examples of valid formats:

--- a/src/tests/test_formatter.py
+++ b/src/tests/test_formatter.py
@@ -6,11 +6,11 @@ from version_builder.version_data import VersionData
 
 class _CommonVersionData:
     version_data = VersionData(
-        tag="v1.2.3-MyDescriptor1",
+        tag="1.2.3-rc.2",
         commit_id="abcd1234",
-        branch_name="test/branch",
+        branch_name="test-branch",
         is_dirty=False,
-        commits_since_tag=2,
+        commits_since_tag=3,
     )
 
 
@@ -30,17 +30,18 @@ class TestBasicOutput(_CommonVersionData):
 
 namespace plxsversion {
 
-inline constexpr std::string_view VERSION { "v1.2.3-MyDescriptor1.revabcd1234+2commits" };
+inline constexpr std::string_view VERSION { "1.2.3-rc.2+dev.3.abcd1234" };
 inline constexpr unsigned int MAJOR { 1 };
 inline constexpr unsigned int MINOR { 2 };
 inline constexpr unsigned int PATCH { 3 };
-inline constexpr std::string_view VERSION_DESCRIPTOR { "MyDescriptor1" };
-inline constexpr std::string_view TAG { "v1.2.3-MyDescriptor1" };
-inline constexpr unsigned int COMMITS_SINCE_TAG { 2 };
+inline constexpr std::string_view PRE_RELEASE { "rc.2" };
+inline constexpr std::string_view TAG { "1.2.3-rc.2" };
+inline constexpr unsigned int COMMITS_SINCE_TAG { 3 };
 inline constexpr std::string_view COMMIT_ID { "abcd1234" };
-inline constexpr std::string_view BRANCH { "test/branch" };
+inline constexpr std::string_view BRANCH { "test-branch" };
 inline constexpr bool DIRTY_BUILD { false };
 inline constexpr bool DEVELOPMENT_BUILD { true };
+inline constexpr std::string_view BUILD_METADATA { "dev.3.abcd1234" };
 
 } // namespace plxsversion
 
@@ -62,17 +63,18 @@ inline constexpr bool DEVELOPMENT_BUILD { true };
 
 namespace plxsversion {
 
-constexpr const char *VERSION { "v1.2.3-MyDescriptor1.revabcd1234+2commits" };
+constexpr const char *VERSION { "1.2.3-rc.2+dev.3.abcd1234" };
 constexpr unsigned int MAJOR { 1 };
 constexpr unsigned int MINOR { 2 };
 constexpr unsigned int PATCH { 3 };
-constexpr const char *VERSION_DESCRIPTOR { "MyDescriptor1" };
-constexpr const char *TAG { "v1.2.3-MyDescriptor1" };
-constexpr unsigned int COMMITS_SINCE_TAG { 2 };
+constexpr const char *PRE_RELEASE { "rc.2" };
+constexpr const char *TAG { "1.2.3-rc.2" };
+constexpr unsigned int COMMITS_SINCE_TAG { 3 };
 constexpr const char *COMMIT_ID { "abcd1234" };
-constexpr const char *BRANCH { "test/branch" };
+constexpr const char *BRANCH { "test-branch" };
 constexpr bool DIRTY_BUILD { false };
 constexpr bool DEVELOPMENT_BUILD { true };
+constexpr const char *BUILD_METADATA { "dev.3.abcd1234" };
 
 } // namespace plxsversion
 
@@ -97,17 +99,18 @@ constexpr bool DEVELOPMENT_BUILD { true };
 extern "C" {
 #endif
 
-static const char *VERSION = "v1.2.3-MyDescriptor1.revabcd1234+2commits";
+static const char *VERSION = "1.2.3-rc.2+dev.3.abcd1234";
 static const unsigned int MAJOR = 1;
 static const unsigned int MINOR = 2;
 static const unsigned int PATCH = 3;
-static const char *VERSION_DESCRIPTOR = "MyDescriptor1";
-static const char *TAG = "v1.2.3-MyDescriptor1";
-static const unsigned int COMMITS_SINCE_TAG = 2;
+static const char *PRE_RELEASE = "rc.2";
+static const char *TAG = "1.2.3-rc.2";
+static const unsigned int COMMITS_SINCE_TAG = 3;
 static const char *COMMIT_ID = "abcd1234";
-static const char *BRANCH = "test/branch";
+static const char *BRANCH = "test-branch";
 static bool DIRTY_BUILD = false;
 static bool DEVELOPMENT_BUILD = true;
+static const char *BUILD_METADATA = "dev.3.abcd1234";
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/tests/test_formatter.py
+++ b/src/tests/test_formatter.py
@@ -30,7 +30,7 @@ class TestBasicOutput(_CommonVersionData):
 
 namespace plxsversion {
 
-inline constexpr std::string_view VERSION { "1.2.3-rc.2+dev.3.abcd1234" };
+inline constexpr std::string_view VERSION { "1.2.3-rc.2+dev.3.sha.abcd1234" };
 inline constexpr unsigned int MAJOR { 1 };
 inline constexpr unsigned int MINOR { 2 };
 inline constexpr unsigned int PATCH { 3 };
@@ -41,7 +41,7 @@ inline constexpr std::string_view COMMIT_ID { "abcd1234" };
 inline constexpr std::string_view BRANCH { "test-branch" };
 inline constexpr bool DIRTY_BUILD { false };
 inline constexpr bool DEVELOPMENT_BUILD { true };
-inline constexpr std::string_view BUILD_METADATA { "dev.3.abcd1234" };
+inline constexpr std::string_view BUILD_METADATA { "dev.3.sha.abcd1234" };
 
 } // namespace plxsversion
 
@@ -63,7 +63,7 @@ inline constexpr std::string_view BUILD_METADATA { "dev.3.abcd1234" };
 
 namespace plxsversion {
 
-constexpr const char *VERSION { "1.2.3-rc.2+dev.3.abcd1234" };
+constexpr const char *VERSION { "1.2.3-rc.2+dev.3.sha.abcd1234" };
 constexpr unsigned int MAJOR { 1 };
 constexpr unsigned int MINOR { 2 };
 constexpr unsigned int PATCH { 3 };
@@ -74,7 +74,7 @@ constexpr const char *COMMIT_ID { "abcd1234" };
 constexpr const char *BRANCH { "test-branch" };
 constexpr bool DIRTY_BUILD { false };
 constexpr bool DEVELOPMENT_BUILD { true };
-constexpr const char *BUILD_METADATA { "dev.3.abcd1234" };
+constexpr const char *BUILD_METADATA { "dev.3.sha.abcd1234" };
 
 } // namespace plxsversion
 
@@ -99,7 +99,7 @@ constexpr const char *BUILD_METADATA { "dev.3.abcd1234" };
 extern "C" {
 #endif
 
-static const char *VERSION = "1.2.3-rc.2+dev.3.abcd1234";
+static const char *VERSION = "1.2.3-rc.2+dev.3.sha.abcd1234";
 static const unsigned int MAJOR = 1;
 static const unsigned int MINOR = 2;
 static const unsigned int PATCH = 3;
@@ -110,7 +110,7 @@ static const char *COMMIT_ID = "abcd1234";
 static const char *BRANCH = "test-branch";
 static bool DIRTY_BUILD = false;
 static bool DEVELOPMENT_BUILD = true;
-static const char *BUILD_METADATA = "dev.3.abcd1234";
+static const char *BUILD_METADATA = "dev.3.sha.abcd1234";
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -12,7 +12,7 @@ class TestMain:
     def test_cpp_source_git(self, tmp_path):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.0.0-alpha.1")
         main.create_version_file(
             source="git",
             source_input=git_dir.path,
@@ -25,10 +25,10 @@ class TestMain:
     def test_cpp_source_file(self, tmp_path):
         git_dir = GitDir(tmp_path)
         file = git_dir.path / "version.txt"
-        file.write_text("1.2.3")
+        file.write_text("1.1.0-beta.2+build.meta")  # More complex SemVer from file
         git_dir.add_all()
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        # The git tag is mostly for git context here, version comes from file
         main.create_version_file(
             source="file",
             source_input=file,
@@ -41,7 +41,7 @@ class TestMain:
     def test_print_file(self, tmp_path, capsys):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v0.1.0-rc.1")
         optional_config = main.OptionalConfiguration(print_created_file=True)
         main.create_version_file(
             source="git",
@@ -56,7 +56,7 @@ class TestMain:
     def test_cpp(self, tmp_path):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.0.0")
         with pytest.raises(ValueError, match="Unexpected file ending for lang"):
             # incorrect version file extension
             main.create_version_file(
@@ -69,7 +69,7 @@ class TestMain:
     def test_c(self, tmp_path):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.0.0")
         with pytest.raises(ValueError, match="Unexpected file ending for lang"):
             # incorrect version file extension
             main.create_version_file(
@@ -90,7 +90,7 @@ class TestMain:
     def test_cpp11(self, tmp_path):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.0.0")
         with pytest.raises(ValueError, match="Unexpected file ending for lang"):
             # incorrect version file extension
             main.create_version_file(
@@ -113,7 +113,7 @@ class TestModuleInterface:
     def test_module_call(self, tmp_path):
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v2.0.0-final+build.123")
         subprocess.check_call(
             [
                 sys.executable,

--- a/src/tests/test_version_collector.py
+++ b/src/tests/test_version_collector.py
@@ -8,38 +8,41 @@ from version_builder.version_data import VersionParseError
 
 
 class TestVersionCollectorGit:
-    def test_data_validation(self, tmp_path):
+    def test_data_validation(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         git_dir.create_branch("test")
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.2.3-alpha.1")  # Collector should strip 'v'
         git_dir.commit()
         expected_commit_id = git_dir.commit()
         version_data = from_git(git_dir.path)
-        assert version_data.tag == "v1.2.3-My_Descriptor_123"
+        assert version_data.tag == "1.2.3-alpha.1"  # VersionData gets the stripped tag
         assert expected_commit_id == version_data.commit_id
         assert version_data.commits_since_tag == 2
         assert version_data.branch_name == "test"
 
-    def test_valid_tags(self, tmp_path):
+    def test_valid_tags(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         git_dir.commit()
         git_dir.tag("1.2.3")
         from_git(git_dir.path)
         git_dir.commit()
-        git_dir.tag("1.2.3-My_Descriptor_123")
+        git_dir.tag("1.2.3-alpha-beta")  # Valid SemVer
         from_git(git_dir.path)
         git_dir.commit()
         git_dir.tag("v1.2.3")
         from_git(git_dir.path)
         git_dir.commit()
-        git_dir.tag("v1.2.3-My_Descriptor_123")
+        git_dir.tag("v1.2.3-rc.1+build.123")  # Valid SemVer with 'v' prefix
         from_git(git_dir.path)
 
-    def test_invalid_tag(self, tmp_path):
+    def test_invalid_tag(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         git_dir.commit()
-        git_dir.tag("1.2.3.4")
+        git_dir.tag("1.2.3.4")  # Invalid: too many components
+        with pytest.raises(VersionParseError):
+            from_git(git_dir.path)
+        git_dir.tag("v1.2.3-Invalid_Tag")  # Invalid: underscore in prerelease
         with pytest.raises(VersionParseError):
             from_git(git_dir.path)
 
@@ -67,7 +70,7 @@ class TestVersionCollectorGit:
         version_data = from_git(git_dir.path)
         assert version_data.is_dirty
 
-    def test_branch_change(self, tmp_path):
+    def test_branch_change(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         git_dir.create_branch("test")
         git_dir.commit()
@@ -78,7 +81,7 @@ class TestVersionCollectorGit:
         version_data = from_git(git_dir.path)
         assert version_data.branch_name == "new-branch"
 
-    def test_detached_head(self, tmp_path):
+    def test_detached_head(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         detached_commit = git_dir.commit()
         git_dir.commit()
@@ -91,7 +94,7 @@ class TestVersionCollectorFile:
     def test_valid_file_in_repo(self, tmp_path):
         git_dir = GitDir(tmp_path)
         file = git_dir.path / "version.txt"
-        file.write_text("1.2.3-MyDescriptor")
+        file.write_text("v1.2.3-alpha.2")  # File content with 'v'
         git_dir.add_all()
         git_dir.create_branch("test")
         expected_commit_id = git_dir.commit()
@@ -100,7 +103,7 @@ class TestVersionCollectorFile:
         assert not version_data.is_dirty
         assert version_data.branch_name == "test"
 
-    def test_valid_file_outside_repo(self, tmp_path):
+    def test_valid_file_outside_repo(self, tmp_path: Path) -> None:
         subdir = tmp_path / "my_dir"
         Path.mkdir(subdir)
         git_dir = GitDir(subdir)
@@ -111,22 +114,22 @@ class TestVersionCollectorFile:
         with pytest.raises(VersionCollectError):
             from_file(file)
 
-    def test_valid_file_no_repo(self, tmp_path):
+    def test_valid_file_no_repo(self, tmp_path: Path) -> None:
         file = tmp_path / "version.txt"
-        file.write_text("1.2.3-MyDescriptor")
+        file.write_text("1.0.0")
         with pytest.raises(VersionCollectError):
             from_file(file)
 
-    def test_empty_file(self, tmp_path):
+    def test_empty_file(self, tmp_path: Path) -> None:
         file = tmp_path / "version.txt"
         file.write_text("")
         with pytest.raises(VersionCollectError):
             from_file(file)
 
-    def test_dirty_repo(self, tmp_path):
+    def test_dirty_repo(self, tmp_path: Path) -> None:
         git_dir = GitDir(tmp_path)
         file = git_dir.path / "version.txt"
-        file.write_text("1.2.3-MyDescriptor")
+        file.write_text("1.2.3")
         git_dir.add_all()
         git_dir.commit()
         dirty_file = git_dir.path / "new_file.txt"

--- a/src/tests/test_version_data.py
+++ b/src/tests/test_version_data.py
@@ -10,25 +10,25 @@ class TestVersionDataSemVerParsing:
 
     def test_tag_not_dirty_default_commits(self):
         data = VersionData(tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        assert data.qualified_version == "1.2.3+abcd1234"
+        assert data.qualified_version == "1.2.3+sha.abcd1234"
         assert data.major == 1
         assert data.minor == 2
         assert data.patch == 3
         assert data.prerelease == ""
         assert data.buildmetadata_from_tag == ""
-        assert data.full_build_metadata == "abcd1234"
+        assert data.full_build_metadata == "sha.abcd1234"
 
     def test_tag_dirty_default_commits(self):
         data = VersionData(tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=True)
-        assert data.qualified_version == "1.2.3+abcd1234.dirty"
-        assert data.full_build_metadata == "abcd1234.dirty"
+        assert data.qualified_version == "1.2.3+sha.abcd1234.dirty"
+        assert data.full_build_metadata == "sha.abcd1234.dirty"
 
     def test_tag_not_dirty_new_commits(self):
         data = VersionData(
             tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False, commits_since_tag=5
         )
-        assert data.qualified_version == "1.2.3+dev.5.abcd1234"
-        assert data.full_build_metadata == "dev.5.abcd1234"
+        assert data.qualified_version == "1.2.3+dev.5.sha.abcd1234"
+        assert data.full_build_metadata == "dev.5.sha.abcd1234"
 
     def test_full_semver_tag_data_verification(self):
         input_tag = "1.0.0-alpha.1+build.original"
@@ -42,7 +42,7 @@ class TestVersionDataSemVerParsing:
         expected_prerelease = "alpha.1"
         expected_buildmetadata_from_tag = "build.original"
         expected_is_development_build = True
-        expected_full_build_metadata = "build.original.dev.5.abcd1234.dirty"
+        expected_full_build_metadata = "build.original.dev.5.sha.abcd1234.dirty"
         expected_qualified_version = f"1.0.0-alpha.1+{expected_full_build_metadata}"
 
         data = VersionData(
@@ -70,8 +70,8 @@ class TestVersionDataSemVerParsing:
         assert data.patch == 1
         assert data.prerelease == "beta.2"
         assert data.buildmetadata_from_tag == ""
-        assert data.qualified_version == "2.0.1-beta.2+abcd1234"
-        assert data.full_build_metadata == "abcd1234"
+        assert data.qualified_version == "2.0.1-beta.2+sha.abcd1234"
+        assert data.full_build_metadata == "sha.abcd1234"
 
     def test_tag_with_build_metadata_only(self):
         data = VersionData(tag="0.0.1+exp.sha.5114f85", commit_id="abcd1234", branch_name="b", is_dirty=True)
@@ -80,8 +80,8 @@ class TestVersionDataSemVerParsing:
         assert data.patch == 1
         assert data.prerelease == ""
         assert data.buildmetadata_from_tag == "exp.sha.5114f85"
-        assert data.qualified_version == "0.0.1+exp.sha.5114f85.abcd1234.dirty"
-        assert data.full_build_metadata == "exp.sha.5114f85.abcd1234.dirty"
+        assert data.qualified_version == "0.0.1+exp.sha.5114f85.sha.abcd1234.dirty"
+        assert data.full_build_metadata == "exp.sha.5114f85.sha.abcd1234.dirty"
 
     def test_invalid_semver_tags(self):
         invalid_tags = [

--- a/src/tests/test_version_data.py
+++ b/src/tests/test_version_data.py
@@ -83,8 +83,9 @@ class TestVersionDataSemVerParsing:
         assert data.qualified_version == "0.0.1+exp.sha.5114f85.sha.abcd1234.dirty"
         assert data.full_build_metadata == "exp.sha.5114f85.sha.abcd1234.dirty"
 
-    def test_invalid_semver_tags(self):
-        invalid_tags = [
+    @pytest.mark.parametrize(
+        "invalid_tag",
+        [
             "v1.2.3",  # 'v' prefix is handled by collector, not VersionData directly
             "a1.2.3",  # Invalid char at start
             "1.2",  # Missing patch component
@@ -97,13 +98,15 @@ class TestVersionDataSemVerParsing:
             "1.2.3+build..meta",  # Empty build metadata identifier
             "1.2.3+",  # Empty build metadata
             "1.2.3-",  # Empty prerelease
+            "1.2.3+sha.abcd1234-alpha.1",  # Build data ahead of pre-release
             "Invalid-TAG",
             "1.2.3 MyDescriptor",
             "1.2.3MyDescriptor",
-        ]
-        for invalid_tag in invalid_tags:
-            with pytest.raises(VersionParseError, match="invalid SemVer 2.0.0 format"):
-                VersionData(tag=invalid_tag, commit_id="id", branch_name="b")
+        ],
+    )
+    def test_invalid_semver_tags(self, invalid_tag):
+        with pytest.raises(VersionParseError, match="invalid SemVer 2.0.0 format"):
+            VersionData(tag=invalid_tag, commit_id="abcd1234", branch_name="test-branch")
 
 
 class TestVersionDataDevelopmentFlag:

--- a/src/tests/test_version_data.py
+++ b/src/tests/test_version_data.py
@@ -3,138 +3,107 @@ import pytest
 from version_builder.version_data import VersionData, VersionParseError
 
 
-class TestVersionDataTag:
+class TestVersionDataSemVerParsing:
     def test_no_tag_not_allowed(self):
         with pytest.raises(VersionParseError):
             VersionData(tag="", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
 
-    # Semantic version testing
     def test_tag_not_dirty_default_commits(self):
-        expected_qualified_version = "1.2.3"
         data = VersionData(tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        assert expected_qualified_version == data.qualified_version
+        assert data.qualified_version == "1.2.3+abcd1234"
+        assert data.major == 1
+        assert data.minor == 2
+        assert data.patch == 3
+        assert data.prerelease == ""
+        assert data.buildmetadata_from_tag == ""
+        assert data.full_build_metadata == "abcd1234"
 
     def test_tag_dirty_default_commits(self):
-        expected_qualified_version = "1.2.3-dirty"
         data = VersionData(tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=True)
-        assert expected_qualified_version == data.qualified_version
+        assert data.qualified_version == "1.2.3+abcd1234.dirty"
+        assert data.full_build_metadata == "abcd1234.dirty"
 
     def test_tag_not_dirty_new_commits(self):
-        expected_qualified_version = "1.2.3.revabcd1234+5commits"
         data = VersionData(
             tag="1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False, commits_since_tag=5
         )
-        assert expected_qualified_version == data.qualified_version
+        assert data.qualified_version == "1.2.3+dev.5.abcd1234"
+        assert data.full_build_metadata == "dev.5.abcd1234"
 
-    # (alternative name) test_tag_dirty_new_commits
-    def test_tag_data_verification(self):
-        expected_tag = "1.2.3"
+    def test_full_semver_tag_data_verification(self):
+        input_tag = "1.0.0-alpha.1+build.original"
         expected_commit_id = "abcd1234"
         expected_branch_name = "test/branch"
         expected_is_dirty = True
-        expected_components = [1, 2, 3]
-        expected_descriptor = ""
+        expected_commits_since_tag = 5
+        expected_major = 1
+        expected_minor = 0
+        expected_patch = 0
+        expected_prerelease = "alpha.1"
+        expected_buildmetadata_from_tag = "build.original"
         expected_is_development_build = True
-        expected_qualified_version = "1.2.3.revabcd1234+5commits-dirty"
+        expected_full_build_metadata = "build.original.dev.5.abcd1234.dirty"
+        expected_qualified_version = f"1.0.0-alpha.1+{expected_full_build_metadata}"
+
         data = VersionData(
-            tag="1.2.3", commit_id="abcd1234", branch_name="test/branch", is_dirty=True, commits_since_tag=5
+            tag=input_tag,
+            commit_id=expected_commit_id,
+            branch_name=expected_branch_name,
+            is_dirty=expected_is_dirty,
+            commits_since_tag=expected_commits_since_tag,
         )
         assert expected_qualified_version == data.qualified_version
-        assert expected_tag == data.tag
+        assert input_tag == data.tag  # raw input tag
         assert expected_commit_id == data.commit_id
         assert expected_branch_name == data.branch_name
         assert expected_is_dirty == data.is_dirty
-        assert expected_components == data.components
-        assert expected_descriptor == data.descriptor
+        assert [expected_major, expected_minor, expected_patch] == data.components
+        assert expected_prerelease == data.prerelease
+        assert expected_buildmetadata_from_tag == data.buildmetadata_from_tag
+        assert expected_full_build_metadata == data.full_build_metadata
         assert expected_is_development_build == data.is_development_build
 
-    def test_tag_leading_char(self):
-        expected_tag = "v1.2.3"
-        expected_components = [1, 2, 3]
-        expected_qualified_version = "v1.2.3"
-        data = VersionData(tag="v1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        assert expected_qualified_version == data.qualified_version
-        assert expected_tag == data.tag
-        assert expected_components == data.components
+    def test_tag_with_prerelease_only(self):
+        data = VersionData(tag="2.0.1-beta.2", commit_id="abcd1234", branch_name="b")
+        assert data.major == 2
+        assert data.minor == 0
+        assert data.patch == 1
+        assert data.prerelease == "beta.2"
+        assert data.buildmetadata_from_tag == ""
+        assert data.qualified_version == "2.0.1-beta.2+abcd1234"
+        assert data.full_build_metadata == "abcd1234"
 
-    def test_tag_bad_leading_char(self):
-        with pytest.raises(VersionParseError):
-            VersionData(tag="a1.2.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
+    def test_tag_with_build_metadata_only(self):
+        data = VersionData(tag="0.0.1+exp.sha.5114f85", commit_id="abcd1234", branch_name="b", is_dirty=True)
+        assert data.major == 0
+        assert data.minor == 0
+        assert data.patch == 1
+        assert data.prerelease == ""
+        assert data.buildmetadata_from_tag == "exp.sha.5114f85"
+        assert data.qualified_version == "0.0.1+exp.sha.5114f85.abcd1234.dirty"
+        assert data.full_build_metadata == "exp.sha.5114f85.abcd1234.dirty"
 
-    def test_tag_enforce_semantic_versioning(self):
-        with pytest.raises(VersionParseError):
-            # missing field
-            VersionData(tag="1.3", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            # extra field
-            VersionData(tag="1.2.3.4", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-
-    def test_tag_is_all_text(self):
-        with pytest.raises(VersionParseError):
-            VersionData(tag="Invalid-TAG", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="InvalidTAG", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="Invalid TAG", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="Invalid_TAG", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-
-
-class TestVersionDataDescriptor:
-    def test_valid_formats(self):
-        VersionData(
-            tag="1.2.3-MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=True, commits_since_tag=5
-        )
-        VersionData(
-            tag="1.2.3-MyDescriptor1", commit_id="abcd1234", branch_name="myBranch", is_dirty=True, commits_since_tag=5
-        )
-        VersionData(
-            tag="1.2.3-My_Descriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=True, commits_since_tag=5
-        )
-        VersionData(
-            tag="1.2.3-1My_Descriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=True, commits_since_tag=5
-        )
-
-    def test_data_verification(self):
-        expected_components = [1, 2, 3]
-        expected_descriptor = "1My_Descriptor2"
-        expected_qualified_version = "1.2.3-1My_Descriptor2.revabcd1234+5commits-dirty"
-        data = VersionData(
-            tag="1.2.3-1My_Descriptor2",
-            commit_id="abcd1234",
-            branch_name="myBranch",
-            is_dirty=True,
-            commits_since_tag=5,
-        )
-        assert expected_qualified_version == data.qualified_version
-        assert expected_components == data.components
-        assert expected_descriptor == data.descriptor
-
-    def test_invalid_content(self):
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3-My-Descriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3-My.Descriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3-MyDescriptor!", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-
-    def test_invalid_separator(self):
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3 MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3_MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3/MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-
-    def test_invalid_semantic_version(self):
-        with pytest.raises(VersionParseError):
-            VersionData(tag="-MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.3-MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
-        with pytest.raises(VersionParseError):
-            VersionData(tag="1.2.3.4-MyDescriptor", commit_id="abcd1234", branch_name="myBranch", is_dirty=False)
+    def test_invalid_semver_tags(self):
+        invalid_tags = [
+            "v1.2.3",  # 'v' prefix is handled by collector, not VersionData directly
+            "a1.2.3",  # Invalid char at start
+            "1.2",  # Missing patch component
+            "1.2.3.4",  # Too many components
+            "1.2.3-alpha_beta",  # Underscore in prerelease identifier
+            "1.2.3-alpha..beta",  # Empty prerelease identifier
+            "1.2.3-01",  # Leading zero in numeric prerelease identifier
+            "1.2.3-alpha!",  # Invalid char in prerelease
+            "1.2.3+build_meta",  # Underscore in build metadata (SemVer allows only [0-9A-Za-z-])
+            "1.2.3+build..meta",  # Empty build metadata identifier
+            "1.2.3+",  # Empty build metadata
+            "1.2.3-",  # Empty prerelease
+            "Invalid-TAG",
+            "1.2.3 MyDescriptor",
+            "1.2.3MyDescriptor",
+        ]
+        for invalid_tag in invalid_tags:
+            with pytest.raises(VersionParseError, match="invalid SemVer 2.0.0 format"):
+                VersionData(tag=invalid_tag, commit_id="id", branch_name="b")
 
 
 class TestVersionDataDevelopmentFlag:

--- a/src/tests/test_version_data.py
+++ b/src/tests/test_version_data.py
@@ -98,7 +98,6 @@ class TestVersionDataSemVerParsing:
             "1.2.3+build..meta",  # Empty build metadata identifier
             "1.2.3+",  # Empty build metadata
             "1.2.3-",  # Empty prerelease
-            "1.2.3+sha.abcd1234-alpha.1",  # Build data ahead of pre-release
             "Invalid-TAG",
             "1.2.3 MyDescriptor",
             "1.2.3MyDescriptor",

--- a/src/version_builder/formatter.py
+++ b/src/version_builder/formatter.py
@@ -41,16 +41,17 @@ class _CppFormatter(_Formatter):
 namespace plxsversion {{
 
 inline constexpr std::string_view VERSION {{ "{version_data.qualified_version:s}" }};
-inline constexpr unsigned int MAJOR {{ {version_data.components[0]:d} }};
-inline constexpr unsigned int MINOR {{ {version_data.components[1]:d} }};
-inline constexpr unsigned int PATCH {{ {version_data.components[2]:d} }};
-inline constexpr std::string_view VERSION_DESCRIPTOR {{ "{version_data.descriptor:s}" }};
+inline constexpr unsigned int MAJOR {{ {version_data.major:d} }};
+inline constexpr unsigned int MINOR {{ {version_data.minor:d} }};
+inline constexpr unsigned int PATCH {{ {version_data.patch:d} }};
+inline constexpr std::string_view PRE_RELEASE {{ "{version_data.prerelease:s}" }};
 inline constexpr std::string_view TAG {{ "{version_data.tag:s}" }};
 inline constexpr unsigned int COMMITS_SINCE_TAG {{ {version_data.commits_since_tag:d} }};
 inline constexpr std::string_view COMMIT_ID {{ "{version_data.commit_id:s}" }};
 inline constexpr std::string_view BRANCH {{ "{version_data.branch_name:s}" }};
 inline constexpr bool DIRTY_BUILD {{ {str(version_data.is_dirty).lower():s} }};
 inline constexpr bool DEVELOPMENT_BUILD {{ {str(version_data.is_development_build).lower():s} }};
+inline constexpr std::string_view BUILD_METADATA {{ "{version_data.full_build_metadata:s}" }};
 {self._optional_output(version_data):s}
 }} // namespace plxsversion
 
@@ -83,16 +84,17 @@ class _Cpp11Formatter(_Formatter):
 namespace plxsversion {{
 
 constexpr const char *VERSION {{ "{version_data.qualified_version:s}" }};
-constexpr unsigned int MAJOR {{ {version_data.components[0]:d} }};
-constexpr unsigned int MINOR {{ {version_data.components[1]:d} }};
-constexpr unsigned int PATCH {{ {version_data.components[2]:d} }};
-constexpr const char *VERSION_DESCRIPTOR {{ "{version_data.descriptor:s}" }};
+constexpr unsigned int MAJOR {{ {version_data.major:d} }};
+constexpr unsigned int MINOR {{ {version_data.minor:d} }};
+constexpr unsigned int PATCH {{ {version_data.patch:d} }};
+constexpr const char *PRE_RELEASE {{ "{version_data.prerelease:s}" }};
 constexpr const char *TAG {{ "{version_data.tag:s}" }};
 constexpr unsigned int COMMITS_SINCE_TAG {{ {version_data.commits_since_tag:d} }};
 constexpr const char *COMMIT_ID {{ "{version_data.commit_id:s}" }};
 constexpr const char *BRANCH {{ "{version_data.branch_name:s}" }};
 constexpr bool DIRTY_BUILD {{ {str(version_data.is_dirty).lower():s} }};
 constexpr bool DEVELOPMENT_BUILD {{ {str(version_data.is_development_build).lower():s} }};
+constexpr const char *BUILD_METADATA {{ "{version_data.full_build_metadata:s}" }};
 {self._optional_output(version_data):s}
 }} // namespace plxsversion
 
@@ -128,16 +130,17 @@ extern "C" {{
 #endif
 
 static const char *VERSION = "{version_data.qualified_version:s}";
-static const unsigned int MAJOR = {version_data.components[0]:d};
-static const unsigned int MINOR = {version_data.components[1]:d};
-static const unsigned int PATCH = {version_data.components[2]:d};
-static const char *VERSION_DESCRIPTOR = "{version_data.descriptor:s}";
+static const unsigned int MAJOR = {version_data.major:d};
+static const unsigned int MINOR = {version_data.minor:d};
+static const unsigned int PATCH = {version_data.patch:d};
+static const char *PRE_RELEASE = "{version_data.prerelease:s}";
 static const char *TAG = "{version_data.tag:s}";
 static const unsigned int COMMITS_SINCE_TAG = {version_data.commits_since_tag:d};
 static const char *COMMIT_ID = "{version_data.commit_id:s}";
 static const char *BRANCH = "{version_data.branch_name:s}";
 static bool DIRTY_BUILD = {str(version_data.is_dirty).lower():s};
 static bool DEVELOPMENT_BUILD = {str(version_data.is_development_build).lower():s};
+static const char *BUILD_METADATA = "{version_data.full_build_metadata:s}";
 {self._optional_output(version_data):s}
 #ifdef __cplusplus
 }} // extern "C"

--- a/src/version_builder/version_collector.py
+++ b/src/version_builder/version_collector.py
@@ -32,12 +32,20 @@ class _VersionCollector:
 
 class _Git(_VersionCollector):
     def compute_version(self, repo_path: str) -> VersionData:
+        def _process_git_tag(raw_tag: str) -> str:
+            # Strip leading 'v' if present, as SemVer itself doesn't include it.
+            # Ensure it's a 'v' followed by a digit to avoid stripping 'v' from non-version tags.
+            if raw_tag.startswith("v") and len(raw_tag) > 1 and raw_tag[1].isdigit():
+                return raw_tag[1:]
+            return raw_tag
+
         with utils.change_dir(repo_path):
             try:
                 repo_description = utils.Git.get_description()
-                match = re.match(r"([a-zA-Z0-9\.]*-?[a-zA-Z0-9\_]*)-([0-9]*)-g([a-zA-Z0-9]*)", repo_description)
-                if match:
-                    tag = match.group(1)
+                # Example git describe output: "v1.2.3-alpha-2-g1234567" or "my-custom-tag-0-gabcdef0"
+                match = re.match(r"^(.*)-(\d+)-g([0-9a-fA-F]{7,})$", repo_description)
+                if match:  # The regex should match standard git describe --long output if a tag exists
+                    tag = _process_git_tag(match.group(1))  # group(1) is the tag name part
                     commits_since_tag = int(match.group(2))
                     commit_id = match.group(3)
                     return VersionData(
@@ -48,7 +56,7 @@ class _Git(_VersionCollector):
                         commits_since_tag=commits_since_tag,
                     )
                 msg = f'unexpected git describe output "{repo_description:s}"'
-                raise VersionCollectError(msg)
+                raise VersionCollectError(msg)  # This case should ideally not be hit with standard git describe output
             except subprocess.CalledProcessError as exc:
                 # no tag exists
                 total_number_commits = utils.Git.get_commit_count()
@@ -56,7 +64,7 @@ class _Git(_VersionCollector):
                     # There is no git tag, but there are commits
                     commit_id = utils.Git.get_commit_id()
                     return VersionData(
-                        tag="0.0.0-UNTAGGED",
+                        tag="0.0.0-UNTAGGED",  # This is a valid SemVer 2.0.0 pre-release
                         commit_id=commit_id,
                         branch_name=utils.Git.get_branch_name(),
                         is_dirty=utils.Git.get_is_dirty(),
@@ -68,8 +76,14 @@ class _Git(_VersionCollector):
 
 class _File(_VersionCollector):
     def compute_version(self, file_path: str) -> VersionData:
+        def _process_file_tag(raw_tag: str) -> str:
+            # Strip leading 'v' if present, ensuring it's a 'v' followed by a digit.
+            if raw_tag.startswith("v") and len(raw_tag) > 1 and raw_tag[1].isdigit():
+                return raw_tag[1:]
+            return raw_tag
+
         with open(file_path) as input_file:
-            tag = input_file.readline().strip()
+            tag = _process_file_tag(input_file.readline().strip())
             if tag:
                 with utils.change_dir(Path(file_path).parent):
                     # While the tag comes from a file, we assume all projects use git

--- a/src/version_builder/version_data.py
+++ b/src/version_builder/version_data.py
@@ -82,10 +82,10 @@ class VersionData(EqualityByValue):
         if self.commits_since_tag > 0:
             # SemVer build metadata identifiers are alphanumeric and hyphens.
             # Git short hash (commit_id) is typically hex, which is fine.
-            build_time_metadata_sub_elements.append(f"dev.{self.commits_since_tag}.{self.commit_id}")
+            build_time_metadata_sub_elements.append(f"dev.{self.commits_since_tag}.sha.{self.commit_id}")
         else:
             # If on a tag (commits_since_tag is 0), include just the commit hash.
-            build_time_metadata_sub_elements.append(self.commit_id)
+            build_time_metadata_sub_elements.append(f"sha.{self.commit_id}")
         if self.is_dirty:
             build_time_metadata_sub_elements.append("dirty")
 

--- a/src/version_builder/version_data.py
+++ b/src/version_builder/version_data.py
@@ -14,11 +14,12 @@ class VersionParseError(Exception):
 
 
 class VersionData(EqualityByValue):
+    # Official SemVer 2.0.0 regex: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    _SEMVER_REGEX = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa: E501
+
     def __init__(
         self, tag: str, commit_id: str, branch_name: str, *, is_dirty: bool = False, commits_since_tag: int = 0
     ) -> None:
-        self._version_format_regex = r"^v?([0-9]+(?:\.[0-9]+){2}){1}(?:-([A-Za-z0-9\_/]+))?$"
-
         if not isinstance(tag, str):
             msg = "tag is not str type"
             raise TypeError(msg)
@@ -39,8 +40,9 @@ class VersionData(EqualityByValue):
             msg = "empty tag input"
             raise VersionParseError(msg, tag)
 
-        if not re.match(self._version_format_regex, tag, re.IGNORECASE):
-            msg = "invalid format"
+        match = re.match(self._SEMVER_REGEX, tag)
+        if not match:
+            msg = "invalid SemVer 2.0.0 format"
             raise VersionParseError(msg, tag)
 
         self.tag = tag
@@ -48,27 +50,51 @@ class VersionData(EqualityByValue):
         self.branch_name = branch_name
         self.is_dirty = is_dirty
         self.commits_since_tag = commits_since_tag
-        self.components = []
-        self.descriptor = ""
+
+        self.major = int(match.group(1))
+        self.minor = int(match.group(2))
+        self.patch = int(match.group(3))
+        self.components = [self.major, self.minor, self.patch]
+        self.prerelease = match.group(4) or ""  # Pre-release identifiers (e.g., "alpha.1")
+        self.buildmetadata_from_tag = match.group(5) or ""  # Build metadata from tag (e.g., "build.123")
+
         self.time = ""
-        self._parse_tag()
         self._set_qualified_version()
         self.is_development_build = self.is_dirty or (commits_since_tag > 0)
 
     def set_time(self) -> None:
         self.time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
 
-    def _parse_tag(self) -> None:
-        match = re.match(self._version_format_regex, self.tag, re.IGNORECASE)
-        if match:
-            self.components = list(map(int, match.group(1).split(".")))
-            if match.group(2) is not None:
-                self.descriptor = match.group(2)
-
     def _set_qualified_version(self) -> None:
-        computed_version = self.tag
+        core_version = f"{self.major}.{self.minor}.{self.patch}"
+
+        qualified_version_str = core_version
+        if self.prerelease:
+            qualified_version_str += f"-{self.prerelease}"
+
+        # Construct build metadata
+        # Starts with metadata from the tag, then appends build-time information.
+        build_metadata_elements = []
+        if self.buildmetadata_from_tag:
+            build_metadata_elements.append(self.buildmetadata_from_tag)
+
+        build_time_metadata_sub_elements = []
         if self.commits_since_tag > 0:
-            computed_version += f".rev{self.commit_id:s}+{self.commits_since_tag:d}commits"
+            # SemVer build metadata identifiers are alphanumeric and hyphens.
+            # Git short hash (commit_id) is typically hex, which is fine.
+            build_time_metadata_sub_elements.append(f"dev.{self.commits_since_tag}.{self.commit_id}")
+        else:
+            # If on a tag (commits_since_tag is 0), include just the commit hash.
+            build_time_metadata_sub_elements.append(self.commit_id)
         if self.is_dirty:
-            computed_version += "-dirty"
-        self.qualified_version = computed_version
+            build_time_metadata_sub_elements.append("dirty")
+
+        if build_time_metadata_sub_elements:
+            build_metadata_elements.append(".".join(build_time_metadata_sub_elements))
+
+        self.full_build_metadata = ".".join(build_metadata_elements)
+
+        if self.full_build_metadata:
+            qualified_version_str += f"+{self.full_build_metadata}"
+
+        self.qualified_version = qualified_version_str


### PR DESCRIPTION
## Description
Update tag processing to adhere to semantic versioning regex. Update version creation to follow semantic versioning guidelines for pre-release and build meta data.

## Testing
Updated unit test to ensure changes perform as expected. Tested changes on rainbow repos.

## Impact
The changes made here will no longer accept tags which don't adhere to semantic versioning rules. Specifically any previous tags with '_' will need to be updated.

## Additional Information
None

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] If planning to release this version, I have updated the pyproject version number appropriately. 
