### PR TITLE
Plxsep 1666 multiple tags cause versioning issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plxsversion"
-version = "2.0.0"
+version = "2.1.0"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 

--- a/readme.md
+++ b/readme.md
@@ -151,8 +151,8 @@ The created file contains the following information:
 | MINOR                   | The semantic minor component of the tag |
 | PATCH                   | The semantic patch component of the tag |
 | PRE_RELEASE             | The pre-release component of the tag |
-| BUILD_METADATA          | The metadata component of the tag |
-| TAG                     | The raw tag before processing |
+| BUILD_METADATA          | The build metadata component of the tag |
+| TAG                     | The base semantic version tag, with any leading 'v' prefix removed |
 | COMMITS_SINCE_TAG       | Number of commits since the last tag (defaults to 0 if using file for semantic version) |
 | COMMIT_ID               | Commit ID of the git commit used to build |
 | BRANCH                  | Branch of the source used to build |
@@ -237,7 +237,7 @@ Here is a sample of CMake implementation that can help test the above cases:
 # plxsversion_create_target(LANG c)
 
 # version from git
-# plxsversion_create_target(SOURCE git VER_INPUT ${CMAKE_CURRENT_SOURCE_DIR})
+# plxsversion_create_target(SOURCE git INPUT ${CMAKE_CURRENT_SOURCE_DIR})
 
 # version from file
 # plxsversion_create_target(SOURCE file INPUT ${CMAKE_CURRENT_SOURCE_DIR}/version.txt)

--- a/readme.md
+++ b/readme.md
@@ -59,12 +59,40 @@ target_link_libraries(my_app PRIVATE plxsversion-my_app)
 
 ### Manual Usage
 
-This script should be ran as a python module. To do this:
+This script can be run as a Python module. To do this:
 
-1. Navigate to this repository's `src` directory or add this directory to the `PYTHONPATH` environment variable
-2. Invoke the tool: ```python -m version_builder --lang <output_language> --input <git_dir> <output_file>```
+1. Navigate to this repository's `src` directory or add this directory to your `PYTHONPATH` environment variable.
+2. Invoke the tool using the following command structure:
+   ```bash
+   python -m version_builder --source <source_type> --lang <language> --input <path_to_source> <output_file>
+   ```
 
-Other parameters can be found in the public interface for the module. 
+Here are the available arguments:
+
+| Argument | Short | Description | Required |
+|---|---|---|---|
+| `--source` | `-s` | Type of source for version info (`git` or `file`). | Yes |
+| `--lang` | `-l` | Language for the output file (`cpp`, `cpp11`, `c`). | Yes |
+| `--input` | `-i` | Path to the source of version information. | Yes |
+| `file` | | Path for the generated output file. | Yes |
+| `--print` | `-p` | Print the generated file's contents after creation. | No |
+| `--time` | `-t` | Include timestamp data in the version information. | No |
+
+**Example using `git` as a source:**
+
+This command generates a C++ header file (`version.hpp`) from the git history of the current directory (`.`) and prints its contents.
+
+```bash
+python -m version_builder --source git --lang cpp --input . --print version.hpp
+```
+
+**Example using `file` as a source:**
+
+This command generates a C header file (`version.h`) using a version tag from `./version.txt`.
+
+```bash
+python -m version_builder --source file --lang c --input ./version.txt version.h
+```
 
 ### Limitations
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -25,6 +25,24 @@ class TestGitWrapper:
                 git_dir.commit()
                 assert commit_num == utils.Git.get_commit_count()
 
+    def test_get_commit_id(self, tmp_path: Path) -> None:
+        git_dir = GitDir(tmp_path)
+        with utils.change_dir(git_dir.path):
+            short_id_from_helper = git_dir.commit()
+
+            # Test default (short=True)
+            short_id_from_util = utils.Git.get_commit_id()
+            assert short_id_from_util == short_id_from_helper
+            assert len(short_id_from_util) == 7
+
+            # Test short=False
+            full_id_from_util = utils.Git.get_commit_id(short=False)
+            assert len(full_id_from_util) == 40
+            assert full_id_from_util.startswith(short_id_from_util)
+
+            # Test short=True explicitly
+            assert utils.Git.get_commit_id(short=True) == short_id_from_util
+
     def test_cwd_not_empty(self, tmp_path):
         git_dir = GitDir(tmp_path)
         with utils.change_dir(git_dir.path):

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -19,7 +19,7 @@ class GitDir:
         self.add_all()
         with change_dir(self.path):
             self._silent_call(["git", "commit", "--allow-empty", "-m", "message"])
-            return self._silent_call(["git", "rev-parse", "--short", "HEAD"]).strip()
+            return self._silent_call(["git", "rev-parse", "--short=7", "HEAD"]).strip()
 
     def add_all(self):
         with change_dir(self.path):
@@ -39,6 +39,9 @@ class GitDir:
         with change_dir(self.path):
             self._silent_call(["git", "checkout", branch_or_commit_id])
 
-    def tag(self, tag_name):
+    def tag(self, tag_name, commit_id=None):
         with change_dir(self.path):
-            self._silent_call(["git", "tag", tag_name])
+            command = ["git", "tag", tag_name]
+            if commit_id:
+                command.append(commit_id)
+            self._silent_call(command)

--- a/src/version_builder/utils.py
+++ b/src/version_builder/utils.py
@@ -27,11 +27,13 @@ class EqualityByValue:
 
 
 class Git:
+    @staticmethod
     def get_branch_name() -> str:
         # No user input is passed to subprocess calls
         return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode()  # noqa: S603
 
-    def get_commit_id(short: bool = True) -> str:
+    @staticmethod
+    def get_commit_id(*, short: bool = True) -> str:
         # No user input is passed to subprocess calls
         command = ["git", "rev-parse"]
         if short:
@@ -39,11 +41,13 @@ class Git:
         command.append("HEAD")
         return subprocess.check_output(command).strip().decode()  # noqa: S603
 
+    @staticmethod
     def get_description() -> str:
         """Output format: <tag>-<commits_since_tag>-g<commit_hash_abbrev>."""
         # No user input is passed to subprocess calls
         return subprocess.check_output(["git", "describe", "--tags", "--abbrev=7", "--long"]).strip().decode()  # noqa: S603
 
+    @staticmethod
     def get_commit_count() -> int:
         try:
             # No user input is passed to subprocess calls
@@ -52,6 +56,7 @@ class Git:
             # HEAD likely does not exist, meaning no commits
             return 0
 
+    @staticmethod
     def get_cwd_is_not_empty() -> bool:
         """Return true if a directory contains files besides a .git directory."""
         # listdir offers a simpler and more readable way to collect all files in a directory
@@ -59,6 +64,7 @@ class Git:
         nongit_entries = [entry for entry in all_entries if entry != ".git"]
         return len(nongit_entries) != 0
 
+    @staticmethod
     def get_is_dirty() -> bool:
         # No user input is passed to subprocess calls
         staged_changes = subprocess.call(["git", "diff", "--quiet", "--cached", "--exit-code", "HEAD"]) != 0  # noqa: S603

--- a/src/version_builder/utils.py
+++ b/src/version_builder/utils.py
@@ -31,9 +31,13 @@ class Git:
         # No user input is passed to subprocess calls
         return subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode()  # noqa: S603
 
-    def get_commit_id() -> str:
+    def get_commit_id(short: bool = True) -> str:
         # No user input is passed to subprocess calls
-        return subprocess.check_output(["git", "rev-parse", "--short=7", "HEAD"]).strip().decode()  # noqa: S603
+        command = ["git", "rev-parse"]
+        if short:
+            command.append("--short=7")
+        command.append("HEAD")
+        return subprocess.check_output(command).strip().decode()  # noqa: S603
 
     def get_description() -> str:
         """Output format: <tag>-<commits_since_tag>-g<commit_hash_abbrev>."""

--- a/src/version_builder/version_collector.py
+++ b/src/version_builder/version_collector.py
@@ -60,7 +60,7 @@ class _Git(_VersionCollector):
 
             # Rule 2: check for multiple valid semver tags on current commit
             try:
-                tags_on_commit_raw = subprocess.check_output(
+                tags_on_commit_raw = subprocess.check_output(  # noqa: S603
                     ["git", "tag", "--points-at", commit_id_full], stderr=subprocess.PIPE
                 ).decode()
                 tags_on_commit = [tag for tag in tags_on_commit_raw.strip().split("\n") if tag]
@@ -86,7 +86,7 @@ class _Git(_VersionCollector):
 
             # Rule 1: No valid semver tag on current commit, search history.
             try:
-                all_tags_raw = subprocess.check_output(
+                all_tags_raw = subprocess.check_output(  # noqa: S603
                     ["git", "for-each-ref", "--sort=-creatordate", "--format", "%(refname:short)", "refs/tags"],
                     stderr=subprocess.PIPE,
                 ).decode()
@@ -97,16 +97,18 @@ class _Git(_VersionCollector):
             for tag_name in all_tags:
                 if self._is_valid_semver(tag_name):
                     # Check if it's an ancestor
-                    is_ancestor_proc = subprocess.run(
+                    is_ancestor_proc = subprocess.run(  # noqa: S603
                         ["git", "merge-base", "--is-ancestor", tag_name, "HEAD"], capture_output=True, check=False
                     )
                     if is_ancestor_proc.returncode == 0:
                         # Found the most recent valid semver tag in history.
 
                         # Check for ambiguity on the tagged ancestor commit
-                        tag_commit_id_full = subprocess.check_output(["git", "rev-parse", tag_name]).decode().strip()
+                        tag_commit_id_full = (
+                            subprocess.check_output(["git", "rev-parse", tag_name]).decode().strip()  # noqa: S603
+                        )
                         try:
-                            tags_on_commit_raw = subprocess.check_output(
+                            tags_on_commit_raw = subprocess.check_output(  # noqa: S603
                                 ["git", "tag", "--points-at", tag_commit_id_full], stderr=subprocess.PIPE
                             ).decode()
                             tags_on_commit = [tag for tag in tags_on_commit_raw.strip().split("\n") if tag]
@@ -117,12 +119,12 @@ class _Git(_VersionCollector):
 
                         if len(valid_semver_tags_on_ancestor) > 1:
                             short_tag_commit_id = (
-                                subprocess.check_output(["git", "rev-parse", "--short=7", tag_name]).decode().strip()
+                                subprocess.check_output(["git", "rev-parse", "--short=7", tag_name]).decode().strip()  # noqa: S603
                             )
-                            msg = f"multiple valid SemVer tags on ancestor commit {short_tag_commit_id}: {', '.join(valid_semver_tags_on_ancestor)}"
+                            msg = f"multiple valid SemVer tags on ancestor commit {short_tag_commit_id}: {', '.join(valid_semver_tags_on_ancestor)}"  # noqa: E501
                             raise VersionCollectError(msg)
 
-                        count_raw = subprocess.check_output(
+                        count_raw = subprocess.check_output(  # noqa: S603
                             ["git", "rev-list", "--count", f"{tag_name}..HEAD"]
                         ).decode()
                         commits_since_tag = int(count_raw.strip())


### PR DESCRIPTION
## Description
Update the tool to handle multiple tags on a commit. The tool will not traverse through the branch history and use the first valid semver based tag found. If the commit being used has multiple valid tags, the tool is error out. If the tool errors out, the cmake will delete previously created version file. 

## Testing
Tested the change by running the script manually from command line. Tested applying multiple valid and invalid tags to multiple commits. Tested file based version to ensure existing functionality is still working. Tested cmake changes by pulling the branch via CPM into an existing project.

## Impact
No impact to the project.

## Additional Information


## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] If planning to release this version, I have updated the pyproject version number appropriately. 
