### PR TITLE
Update Cargo.toml with license specifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plxsversion"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 license = "MIT"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,6 @@
 name = "plxsversion"
 version = "2.3.0"
 edition = "2024"
+license = "MIT"
 
 [dependencies]


### PR DESCRIPTION
## Description
I received a "cargo deny check licenses" because the license is not specified. 

## Testing
Pointed my branch to latest rev, and saw the cargo deny license warning check get removed.

## Impact
Configuration only

## Additional Information

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] If planning to release this version, I have updated the `pyproject.toml` and `Cargo.toml` version numbers appropriately.
