### PR TITLE
JSON/stdout Output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plxsversion"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2024"
 license = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plxsversion"
-version = "2.3.1"
+version = "2.4.0"
 requires-python = ">=3.10"
 license = "MIT"
 license-files = [ "LICENSE" ]

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Here are the available arguments:
 | `--source` | `-s` | Type of source for version info (`git` or `file`). | Yes |
 | `--lang` | `-l` | Language for the output file (`cpp`, `cpp11`, `c`, `rust`). | Yes |
 | `--input` | `-i` | Path to the source of version information. | Yes |
-| `file` | | Path for the generated output file. | Yes |
+| `file` | | Path for the generated output file. | No |
 | `--print` | `-p` | Print the generated file's contents after creation. | No |
 | `--time` | `-t` | Include timestamp data in the version information. | No |
 | `--namespace` | `-n` | C++ namespace for the version info. Only for `cpp` or `cpp11`. | No |

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Here are the available arguments:
 | `--source` | `-s` | Type of source for version info (`git` or `file`). | Yes |
 | `--lang` | `-l` | Language for the output file (`cpp`, `cpp11`, `c`, `rust`). | Yes |
 | `--input` | `-i` | Path to the source of version information. | Yes |
-| `file` | | Path for the generated output file. | No |
+| `file` | | Path for the generated output file. Defaults to `stdout` if not specified. | No |
 | `--print` | `-p` | Print the generated file's contents after creation. | No |
 | `--time` | `-t` | Include timestamp data in the version information. | No |
 | `--namespace` | `-n` | C++ namespace for the version info. Only for `cpp` or `cpp11`. | No |

--- a/src/version_builder/__main__.py
+++ b/src/version_builder/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from version_builder import main
 
@@ -8,7 +9,7 @@ def execute() -> None:
     parser.add_argument(
         "--lang",
         "-l",
-        choices=["cpp", "cpp11", "c", "rust"],
+        choices=["cpp", "cpp11", "c", "rust", "json"],
         required=True,
         help="language supported by the file output",
     )
@@ -45,7 +46,7 @@ def execute() -> None:
         required=False,
         help="cargo version of a crate",
     )
-    parser.add_argument("file")
+    parser.add_argument("file", nargs="?", help="output file to create (stdout if not supplied)")
     args = parser.parse_args()
 
     if args.namespace == "":
@@ -61,7 +62,7 @@ def execute() -> None:
         parser.error("The --cargo argument requires --lang to be set to 'rust'")
 
     # Intentional print for user status notification
-    print(f"Creating version information using {args.source:s} from {args.input:s}")  # noqa: T201
+    print(f"Creating version information using {args.source:s} from {args.input:s}", file=sys.stderr)  # noqa: T201
 
     main.create_version_file(
         source=args.source,

--- a/src/version_builder/formatter.py
+++ b/src/version_builder/formatter.py
@@ -1,3 +1,5 @@
+import json
+
 from version_builder.version_data import VersionData
 
 
@@ -15,6 +17,10 @@ def to_c(version_data: VersionData) -> str:
 
 def to_rust(version_data: VersionData) -> str:
     return _RustFormatter().format(version_data)
+
+
+def to_json(version_data: VersionData) -> str:
+    return _JsonFormatter().format(version_data)
 
 
 class _Formatter:
@@ -216,4 +222,41 @@ pub mod plxsversion {{
             optional_output += f"""\tpub const UTC_TIME: &str = "{version_data.time:s}";\n"""
         if version_data.cargo_version:
             optional_output += f"""\tpub const CARGO_VERSION: &str = "{version_data.cargo_version:s}";\n"""
+        return optional_output
+
+
+# ----------------------------------------
+# JSON Formatter
+# ----------------------------------------
+
+
+class _JsonFormatter(_Formatter):
+    def main_formatter(self, version_data: VersionData) -> str:
+
+        json_structure = {
+            "BASE_VERSION": version_data.base_version,
+            "VERSION": version_data.qualified_version,
+            "MAJOR": version_data.major,
+            "MINOR": version_data.minor,
+            "PATCH": version_data.patch,
+            "PRE_RELEASE": version_data.prerelease,
+            "TAG": version_data.tag,
+            "COMMITS_SINCE_TAG": version_data.commits_since_tag,
+            "COMMIT_ID": version_data.commit_id,
+            "BRANCH": version_data.branch_name,
+            "DIRTY_BUILD": version_data.is_dirty,
+            "DEVELOPMENT_BUILD": version_data.is_development_build,
+            "BUILD_METADATA": version_data.full_build_metadata,
+        }
+
+        json_structure.update(self._optional_output(version_data))
+
+        return json.dumps(json_structure)
+
+    def _optional_output(self, version_data: VersionData) -> str:
+        optional_output = {}
+        if version_data.time:
+            optional_output["UTC_TIME"] = version_data.time
+        if version_data.cargo_version:
+            optional_output["CARGO_VERSION"] = version_data.cargo_version
         return optional_output

--- a/src/version_builder/main.py
+++ b/src/version_builder/main.py
@@ -38,7 +38,7 @@ def create_version_file(
 
     _output_version_file(
         version_info=version_info,
-        output_file=PosixPath(output_file),
+        output_file=PosixPath(output_file) if output_file is not None else None,
         lang=lang,
         namespace=optional_config.namespace,
         print_created_file=optional_config.print_created_file,
@@ -79,9 +79,17 @@ def _output_version_file(
         case "rust":
             output = formatter.to_rust(version_info)
             expected_file_extension = ".rs"
+        case "json":
+            output = formatter.to_json(version_info)
+            expected_file_extension = ".json"
         case _:
             msg = "Unknown language"
             raise ValueError(msg)
+
+    if output_file is None:
+        # Intentional print to put the output object on stdout
+        print(f"{output}")  # noqa: T201
+        return
 
     if output_file.suffix != expected_file_extension:
         msg = (


### PR DESCRIPTION
## Description
This PR:
* Adds a JSON output format for easier CLI parsing
* Makes the file output optional, using `stdout` when not provided (also for easier CLI parsing)

## Testing
This was tested locally on the command line with the `plxsversion` repository, where the following command:
```bash
$ python -m version_builder -s git -i . -l json | jq
```
produced the following output:
```json
Creating version information using git from .
{
  "BASE_VERSION": "2.3.1",
  "VERSION": "2.3.1+dev.1.sha.2f70f1b.dirty",
  "MAJOR": 2,
  "MINOR": 3,
  "PATCH": 1,
  "PRE_RELEASE": "",
  "TAG": "2.3.1",
  "COMMITS_SINCE_TAG": 1,
  "COMMIT_ID": "2f70f1b",
  "BRANCH": "feature/json-output",
  "DIRTY_BUILD": true,
  "DEVELOPMENT_BUILD": true,
  "BUILD_METADATA": "dev.1.sha.2f70f1b.dirty"
}
```

Additionally, the `pytest` suite was run to confirm that existing invocation patterns don't break.

## Impact
This adds a JSON output, similar to existing output formats.  The file argument becomes optional, but this does not break existing invocations.

Additionally, the project version should be bumped to `2.4.0`, due to the addition of a feature.

## Additional Information
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
- [x] If planning to release this version, I have updated the `pyproject.toml` and `Cargo.toml` version numbers appropriately.
